### PR TITLE
Avoid sending records that should be ignored to any of the configured firehose sink

### DIFF
--- a/src/main/java/org/observertc/observer/sinks/CsvFormatEncoder.java
+++ b/src/main/java/org/observertc/observer/sinks/CsvFormatEncoder.java
@@ -65,6 +65,12 @@ public class CsvFormatEncoder<K, V> implements FormatEncoder<K, V> {
             for (var it = reportsByTypes.entrySet().iterator(); it.hasNext(); ) {
                 var entry = it.next();
                 var type = entry.getKey();
+                K mappedType = typeMapper.apply(report.type);
+
+                if (mappedType == null) {
+                    continue;
+                }
+
                 var groupedReports = entry.getValue();
                 var stringBuilder = new StringBuffer();
                 var csvPrinter = new CSVPrinter(stringBuilder, format);
@@ -79,12 +85,8 @@ public class CsvFormatEncoder<K, V> implements FormatEncoder<K, V> {
                     }
                     csvPrinter.flush();
                     var lines = stringBuilder.toString();
-                    K mappedType = typeMapper.apply(report.type);
                     V myRecord = this.formatMapper.apply(lines);
 
-                    if (mappedType == null) {
-                        continue;
-                    }
                     var mappedRecords = records.get(mappedType);
                     if (mappedRecords == null) {
                         mappedRecords = new LinkedList<>();

--- a/src/main/java/org/observertc/observer/sinks/CsvFormatEncoder.java
+++ b/src/main/java/org/observertc/observer/sinks/CsvFormatEncoder.java
@@ -60,14 +60,16 @@ public class CsvFormatEncoder<K, V> implements FormatEncoder<K, V> {
     public Map<K, List<V>> map(List<Report> reports) {
         try {
             Map<K, List<V>> records = new HashMap<K, List<V>>();
-            var stringBuilder = new StringBuffer();
-            var csvPrinter = new CSVPrinter(stringBuilder, format);
-            var chunkSize = 0;
-            var reportsByTypes = reports.stream().collect(groupingBy(r -> r.type));
+
+
             for (var it = reportsByTypes.entrySet().iterator(); it.hasNext(); ) {
                 var entry = it.next();
                 var type = entry.getKey();
                 var groupedReports = entry.getValue();
+                var stringBuilder = new StringBuffer();
+                var csvPrinter = new CSVPrinter(stringBuilder, format);
+                var chunkSize = 0;
+                var reportsByTypes = reports.stream().collect(groupingBy(r -> r.type));
                 for (var jt = groupedReports.iterator(); jt.hasNext(); ) {
                     var report = jt.next();
                     var iterable = mapper.apply(report, type);
@@ -90,9 +92,6 @@ public class CsvFormatEncoder<K, V> implements FormatEncoder<K, V> {
                     }
 
                     mappedRecords.add(myRecord);
-                    stringBuilder = new StringBuffer();
-                    csvPrinter = new CSVPrinter(stringBuilder, CSVFormat.DEFAULT);
-                    chunkSize = 0;
                 }
             }
             logger.info("Received {} reports ({} types) mapped to {} different type of records", reports.size(), reportsByTypes.size(), records.size());


### PR DESCRIPTION
- Avoid using CsvPrinter for ignored types.
- Avoid processing any records for a report that have no firehose sink
